### PR TITLE
"WPGraphQLTestCommon::assertQueryError()" implemented and tested.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,7 @@
     },
     "require": {
         "php": ">=7.1",
-        "phpunit/phpunit": "^7.5",
-        "codeception/module-asserts": "^1.3",
-        "codeception/util-universalframework": "^1.0",
-        "codeception/module-rest": "^1.2",
-        "lucatume/wp-browser": "^3.0",
-        "wp-phpunit/wp-phpunit": "^5.7"
+        "phpunit/phpunit": "^7.5"
     },
     "require-dev": {
         "composer/installers": "^1.9",

--- a/src/TestCase/WPGraphQLTestCase.php
+++ b/src/TestCase/WPGraphQLTestCase.php
@@ -16,6 +16,12 @@ class WPGraphQLTestCase extends \Codeception\TestCase\WPTestCase {
 
 	use WPGraphQLTestCommon;
 
+	// Search operation enumerations.
+	const MESSAGE_EQUALS      = 100;
+	const MESSAGE_CONTAINS    = 200;
+	const MESSAGE_STARTS_WITH = 300;
+	const MESSAGE_ENDS_WITH   = 400;
+
 	/**
 	 * Console logging function.
 	 *

--- a/src/TestCase/WPGraphQLUnitTestCase.php
+++ b/src/TestCase/WPGraphQLUnitTestCase.php
@@ -9,9 +9,16 @@
 namespace Tests\WPGraphQL\TestCase;
 
 abstract class WPGraphQLUnitTestCase extends \WP_UnitTestCase {
-    use WPGraphQLTestCommon;
 
-    /**
+	use WPGraphQLTestCommon;
+
+	// Search operation enumerations.
+	const MESSAGE_EQUALS      = 500;
+	const MESSAGE_CONTAINS    = 600;
+	const MESSAGE_STARTS_WITH = 700;
+	const MESSAGE_ENDS_WITH   = 800;
+
+	/**
 	 * Console logging function.
 	 *
 	 * Use --debug flag to view in console.

--- a/tests/codeception/wpunit/WPGraphQLTestCaseTest.php
+++ b/tests/codeception/wpunit/WPGraphQLTestCaseTest.php
@@ -2,62 +2,136 @@
 
 class WPGraphQLTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 {
-    /**
-     * @var \WpunitTester
-     */
-    protected $tester;
-    
-    public function setUp(): void {
-        // Before...
-        parent::setUp();
+	/**
+	 * @var \WpunitTester
+	 */
+	protected $tester;
 
-        // Your set up methods here.
-    }
+	public function tearDown(): void {
+		parent::tearDown();
+		WPGraphQL::clear_schema();
+	}
 
-    public function tearDown(): void {
-        // Your tear down methods here.
+	public function testAssertQuerySuccessful() {
+		// Create posts for later use.
+		$post_id          = self::factory()->post->create();
+		$unneeded_post_id = self::factory()->post->create();
 
-        // Then...
-        parent::tearDown();
-    }
+		// GraphQL query and variables.
+		$query     = '
+			query ($id: ID!) {
+				post( id: $id ) {
+					id
+					databaseId
+				}
+				posts {
+					nodes {
+						id
+					}
+				}
+			}
+		';
+		$variables = array(
+			'id' => $this->toRelayId( 'post', $post_id ),
+		);
 
-    public function testAssertQuerySuccessful() {
-        // Create posts for later use.
-        $post_id          = self::factory()->post->create();
-        $unneeded_post_id = self::factory()->post->create();
+		// Execute query and get response.
+		$response = $this->graphql( compact( 'query', 'variables' ) );
 
-        // GraphQL query and variables.
-        $query     = '
-            query ($id: ID!) {
-                post( id: $id ) {
-                    id
-                    databaseId
-                }
-                posts {
-                    nodes {
-                        id
-                    }
-                }
-            }
-        ';
-        $variables = array(
-            'id' => $this->toRelayId( 'post', $post_id ),
-        );
+		// Expected data.
+		$expected = array(
+			$this->expectedObject( 'post.id', $this->toRelayId( 'post', $post_id ) ),
+			$this->expectedObject( 'post.databaseId', $post_id ),
+			$this->expectedNode(
+				'posts.nodes',
+				array( 'id' => $this->toRelayId( 'post', $post_id ) )
+			)
+		);
 
-        // Execute query and get response.
-        $response = $this->graphql( compact( 'query', 'variables' ) );
+		// Assert query successful.
+		$this->assertQuerySuccessful( $response, $expected );
+	}
 
-        // Expected data.
-        $expected = array(
-            $this->expectedObject( 'post.id', $this->toRelayId( 'post', $post_id ) ),
-            $this->expectedObject( 'post.databaseId', $post_id ),
-            $this->expectedNode(
-                'posts.nodes',
-                array( 'id' => $this->toRelayId( 'post', $post_id ) )
-            )
-        );
+	public function testAssertQueryError() {
+		register_graphql_object_type(
+			'FailingType',
+			array(
+				'fields' => array(
+					'try' => array(
+						'type'    => 'String',
+						'args'    => array(
+							'fail' => array(
+								'type' => 'Boolean'
+							)
+						),
+						'resolve' => function( $_, $args ) {
+							if ( ! empty( $args['fail'] ) && $args['fail'] ) {
+								throw new \GraphQL\Error\UserError( 'testErrorQuery worked as expected' );
+							}
+							
+							return 'No fails here';
+						}
+					),
+					'trying' => array(
+						'type'    => array( 'list_of' => 'String' ),
+						'args'    => array(
+							'fail' => array(
+								'type' => 'Boolean'
+							)
+						),
+						'resolve' => function( $_, $args ) {                            
+							return ! empty( $args['fail'] ) && $args['fail']
+								? absint(1.1)
+								: [ 'No', 'fails', 'here', 'either' ];
+						}
+					)
+				),
+			)
+		);
 
-        // Assert query successful.
-        $this->assertQuerySuccessful( $response, $expected );
-    }
+		register_graphql_field(
+			'RootQuery',
+			'testFailingType',
+			array(
+				'type'    => 'FailingType',
+				'resolve' => function() {
+					return [];
+				},
+			)
+		);
+
+		$query     = 'query( $fail1: Boolean, $fail2: Boolean ) {
+			testFailingType {
+				try( fail: $fail1 )
+				trying( fail: $fail2 )
+			}
+		}';
+		$variables = array( 'fail1' => true );
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+
+		$expected = array(
+			$this->expectedErrorPath( 'testFailingType.try' ),
+			$this->expectedErrorMessage( 'testErrorQuery worked as expected', self::MESSAGE_EQUALS ),
+			$this->expectedErrorMessage( 'worked as', self::MESSAGE_CONTAINS ),
+			$this->expectedErrorMessage( 'as expected', self::MESSAGE_ENDS_WITH ),
+			$this->expectedErrorMessage( 'testErrorQuery worked', self::MESSAGE_STARTS_WITH ),
+			$this->expectedObject( 'testFailingType.try', 'NULL' ),
+			$this->expectedObject( 'testFailingType.trying', [ 'No', 'fails', 'here', 'either' ] ),
+		);
+
+		// Assert response has error.
+		$this->assertQueryError( $response, $expected );
+
+		$variables = array( 'fail2' => true );
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+
+		$expected = array(
+			$this->expectedErrorPath( 'testFailingType.trying' ),
+			$this->expectedObject( 'testFailingType.try', 'No fails here' ),
+			$this->expectedObject( 'testFailingType.trying', 'NULL' ),
+		);
+
+		// Assert response has error.
+		$this->assertQueryError( $response, $expected );
+	}
 }

--- a/tests/phpunit/unit/test-wpgraphqlunittestcase.php
+++ b/tests/phpunit/unit/test-wpgraphqlunittestcase.php
@@ -1,46 +1,133 @@
 <?php
 
-class WPGraphQLUnitTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLUnitTestCase
-{
+class WPGraphQLUnitTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLUnitTestCase {
+	
+	public function tearDown(): void {
+		parent::tearDown();
+		WPGraphQL::clear_schema();
+	}
 
-    /** @test */
-    public function test_AssertQuerySuccessful() {
-        // Create posts for later use.
-        $post_id          = self::factory()->post->create();
-        $unneeded_post_id = self::factory()->post->create();
+	/** @test */
+	public function test_AssertQuerySuccessful() {
+		// Create posts for later use.
+		$post_id          = self::factory()->post->create();
+		$unneeded_post_id = self::factory()->post->create();
 
-        // GraphQL query and variables.
-        $query     = '
-            query ($id: ID!) {
-                post( id: $id ) {
-                    id
-                    databaseId
-                }
-                posts {
-                    nodes {
-                        id
-                    }
-                }
-            }
-        ';
-        $variables = array(
-            'id' => $this->toRelayId( 'post', $post_id ),
-        );
+		// GraphQL query and variables.
+		$query     = '
+			query ($id: ID!) {
+				post( id: $id ) {
+					id
+					databaseId
+				}
+				posts {
+					nodes {
+						id
+					}
+				}
+			}
+		';
+		$variables = array(
+			'id' => $this->toRelayId( 'post', $post_id ),
+		);
 
-        // Execute query and get response.
-        $response = $this->graphql( compact( 'query', 'variables' ) );
+		// Execute query and get response.
+		$response = $this->graphql( compact( 'query', 'variables' ) );
 
-        // Expected data.
-        $expected = array(
-            $this->expectedObject( 'post.id', $this->toRelayId( 'post', $post_id ) ),
-            $this->expectedObject( 'post.databaseId', $post_id ),
-            $this->expectedNode(
-                'posts.nodes',
-                array( 'id' => $this->toRelayId( 'post', $post_id ) )
-            )
-        );
+		// Expected data.
+		$expected = array(
+			$this->expectedObject( 'post.id', $this->toRelayId( 'post', $post_id ) ),
+			$this->expectedObject( 'post.databaseId', $post_id ),
+			$this->expectedNode(
+				'posts.nodes',
+				array( 'id' => $this->toRelayId( 'post', $post_id ) )
+			)
+		);
 
-        // Assert query successful.
-        $this->assertQuerySuccessful( $response, $expected );
-    }
+		// Assert query successful.
+		$this->assertQuerySuccessful( $response, $expected );
+	}
+
+	public function test_AssertQueryError() {
+		register_graphql_object_type(
+			'FailingType',
+			array(
+				'fields' => array(
+					'try' => array(
+						'type'    => 'String',
+						'args'    => array(
+							'fail' => array(
+								'type' => 'Boolean'
+							)
+						),
+						'resolve' => function( $_, $args ) {
+							if ( ! empty( $args['fail'] ) && $args['fail'] ) {
+								throw new \GraphQL\Error\UserError( 'testErrorQuery worked as expected' );
+							}
+							
+							return 'No fails here';
+						}
+					),
+					'trying' => array(
+						'type'    => array( 'list_of' => 'String' ),
+						'args'    => array(
+							'fail' => array(
+								'type' => 'Boolean'
+							)
+						),
+						'resolve' => function( $_, $args ) {                            
+							return ! empty( $args['fail'] ) && $args['fail']
+								? absint(1.1)
+								: [ 'No', 'fails', 'here', 'either' ];
+						}
+					)
+				),
+			)
+		);
+
+		register_graphql_field(
+			'RootQuery',
+			'testFailingType',
+			array(
+				'type'    => 'FailingType',
+				'resolve' => function() {
+					return [];
+				},
+			)
+		);
+
+		$query     = 'query( $fail1: Boolean, $fail2: Boolean ) {
+			testFailingType {
+				try( fail: $fail1 )
+				trying( fail: $fail2 )
+			}
+		}';
+		$variables = array( 'fail1' => true );
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+
+		$expected = array(
+			$this->expectedErrorPath( 'testFailingType.try' ),
+			$this->expectedErrorMessage( 'testErrorQuery worked as expected', self::MESSAGE_EQUALS ),
+			$this->expectedErrorMessage( 'worked as', self::MESSAGE_CONTAINS ),
+			$this->expectedErrorMessage( 'as expected', self::MESSAGE_ENDS_WITH ),
+			$this->expectedErrorMessage( 'testErrorQuery worked', self::MESSAGE_STARTS_WITH ),
+			$this->expectedObject( 'testFailingType.try', 'NULL' ),
+			$this->expectedObject( 'testFailingType.trying', [ 'No', 'fails', 'here', 'either' ] ),
+		);
+
+		// Assert response has error.
+		$this->assertQueryError( $response, $expected );
+
+		$variables = array( 'fail2' => true );
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+
+		$expected = array(
+			$this->expectedErrorPath( 'testFailingType.trying' ),
+			$this->expectedObject( 'testFailingType.try', 'No fails here' ),
+			$this->expectedObject( 'testFailingType.trying', 'NULL' ),
+		);
+
+		// Assert response has error.
+		$this->assertQueryError( $response, $expected );
+	}
 }


### PR DESCRIPTION
## Checklist
- Implements **assertQueryError** assertion see example usage below.
```php
$expected = array(
    $this->expectedErrorPath( 'testFailingType.try' ),
    $this->expectedErrorMessage( 'testErrorQuery worked as expected', self::MESSAGE_EQUALS ),
    $this->expectedErrorMessage( 'worked as', self::MESSAGE_CONTAINS ),
    $this->expectedErrorMessage( 'as expected', self::MESSAGE_ENDS_WITH ),
    $this->expectedErrorMessage( 'testErrorQuery worked', self::MESSAGE_STARTS_WITH ),
    $this->expectedObject( 'testFailingType.try', 'NULL' ),
    $this->expectedObject( 'testFailingType.trying', [ 'No', 'fails', 'here', 'either' ] ),
);

// Assert response has error.
$this->assertQueryError( $response, $expected );
```
- `testAssertQueryError` test added to PHPUnit and Codeception test cases.
- Switch to tab indentations in all PHP files.
