### PR TITLE
"WPGraphQLTestCommon::not()" implemented and tested.

### DIFF
--- a/tests/codeception/wpunit/WPGraphQLTestCaseTest.php
+++ b/tests/codeception/wpunit/WPGraphQLTestCaseTest.php
@@ -45,6 +45,10 @@ class WPGraphQLTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 			$this->expectedNode(
 				'posts.nodes',
 				array( 'id' => $this->toRelayId( 'post', $post_id ) )
+			),
+			$this->not()->expectedNode(
+				'posts.nodes',
+				array( 'id' => $this->toRelayId( 'post', 10001 ) )
 			)
 		);
 

--- a/tests/phpunit/unit/test-wpgraphqlunittestcase.php
+++ b/tests/phpunit/unit/test-wpgraphqlunittestcase.php
@@ -41,6 +41,10 @@ class WPGraphQLUnitTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLUnitT
 			$this->expectedNode(
 				'posts.nodes',
 				array( 'id' => $this->toRelayId( 'post', $post_id ) )
+			),
+			$this->not()->expectedNode(
+				'posts.nodes',
+				array( 'id' => $this->toRelayId( 'post', 10001 ) )
 			)
 		);
 


### PR DESCRIPTION
## Checklist
- Implements the `not()` modifier. See example usage below.
```php
// Execute query and get response.
$response = $this->graphql( compact( 'query', 'variables' ) );

// Expected data.
$expected = array(
	$this->expectedObject( 'post.id', $this->toRelayId( 'post', $post_id ) ),
	$this->expectedObject( 'post.databaseId', $post_id ),
	$this->expectedNode(
		'posts.nodes',
		array( 'id' => $this->toRelayId( 'post', $post_id ) )
	),
	$this->not()->expectedNode(
		'posts.nodes',
		array( 'id' => $this->toRelayId( 'post', 10001 ) )
	)
);

// Assert query successful.
$this->assertQuerySuccessful( $response, $expected );
```
- `testAssertQuerySuccessful` test updated.