### PR TITLE
more bugfixes

### DIFF
--- a/src/TestCase/WPGraphQLTestCommon.php
+++ b/src/TestCase/WPGraphQLTestCommon.php
@@ -28,6 +28,9 @@ trait WPGraphQLTestCommon {
 	public function graphql() {
 		$results = graphql( ...func_get_args() );
 
+		// Clear schema
+		\WPGraphQL::clear_schema();
+
 		// use --debug flag to view.
 		$this->logData( $results );
 
@@ -182,7 +185,7 @@ trait WPGraphQLTestCommon {
 	public function assertExpectedDataFound( array $response, array $expected_data, $message = '' ) {
 		// Throw if "$expected_data" invalid.
 		if ( empty( $expected_data['type'] ) ) {
-			\codecept_debug( array( 'INVALID_DATA_OBJECT' => $expected_data ) );
+			$this->logData( array( 'INVALID_DATA_OBJECT' => $expected_data ) );
 			throw new \Exception( 'Invalid data object provided for evaluation.' );
 		}
 
@@ -422,7 +425,7 @@ trait WPGraphQLTestCommon {
 		foreach( $expected as $expected_data ) {
 			// Throw if "$expected_data" invalid.
 			if ( empty( $expected_data['type'] ) ) {
-				\codecept_debug( array( 'INVALID_DATA_OBJECT' => $expected_data ) );
+				$this->logData( array( 'INVALID_DATA_OBJECT' => $expected_data ) );
 				throw new \Exception( 'Invalid data object provided for evaluation.' );
 			} elseif ( $this->startsWith( 'ERROR_', $expected_data['type'] ) ) {
 				$this->assertExpectedErrorFound( $response, $expected_data, $message );

--- a/src/TestCase/WPGraphQLTestCommon.php
+++ b/src/TestCase/WPGraphQLTestCommon.php
@@ -28,13 +28,20 @@ trait WPGraphQLTestCommon {
 	public function graphql() {
 		$results = graphql( ...func_get_args() );
 
-		// Clear schema
-		\WPGraphQL::clear_schema();
-
 		// use --debug flag to view.
 		$this->logData( $results );
 
 		return $results;
+	}
+
+	/**
+	 * Wrapper for the "\WGraphQL::clear_schema()" function.
+	 *
+	 * @return array
+	 */
+	public function clear_schema() {
+		// Clear schema
+		\WPGraphQL::clear_schema();
 	}
 
 	/**

--- a/tests/codeception/wpunit/WPGraphQLTestCaseTest.php
+++ b/tests/codeception/wpunit/WPGraphQLTestCaseTest.php
@@ -42,6 +42,7 @@ class WPGraphQLTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$expected = array(
 			$this->expectedObject( 'post.id', $this->toRelayId( 'post', $post_id ) ),
 			$this->expectedObject( 'post.databaseId', $post_id ),
+			$this->not()->expectedObject( 'post.databaseId', 10001 ),
 			$this->expectedNode(
 				'posts.nodes',
 				array( 'id' => $this->toRelayId( 'post', $post_id ) )

--- a/tests/phpunit/unit/test-wpgraphqlunittestcase.php
+++ b/tests/phpunit/unit/test-wpgraphqlunittestcase.php
@@ -38,6 +38,7 @@ class WPGraphQLUnitTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLUnitT
 		$expected = array(
 			$this->expectedObject( 'post.id', $this->toRelayId( 'post', $post_id ) ),
 			$this->expectedObject( 'post.databaseId', $post_id ),
+			$this->not()->expectedObject( 'post.databaseId', 10001 ),
 			$this->expectedNode(
 				'posts.nodes',
 				array( 'id' => $this->toRelayId( 'post', $post_id ) )


### PR DESCRIPTION
- Replaces all `\codecept_debug()` calls to `$this->logData()` in the Common class.
- Adds `\WPGraphQL::clear_schema()` to `$this->graphql()` to avoid getting cached responses.