### PR TITLE
Recursive rules support added.

### DIFF
--- a/src/TestCase/WPGraphQLTestCase.php
+++ b/src/TestCase/WPGraphQLTestCase.php
@@ -27,7 +27,7 @@ class WPGraphQLTestCase extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * Use --debug flag to view in console.
 	 */
-	protected function logData( $data ) {
+	public static function logData( $data ) {
 		if ( is_array( $data ) || is_object( $data ) ) {
 			\codecept_debug( json_encode( $data, JSON_PRETTY_PRINT ) );
 			return;

--- a/src/TestCase/WPGraphQLUnitTestCase.php
+++ b/src/TestCase/WPGraphQLUnitTestCase.php
@@ -23,7 +23,7 @@ abstract class WPGraphQLUnitTestCase extends \WP_UnitTestCase {
 	 *
 	 * Use --debug flag to view in console.
 	 */
-	protected function logData( $data ) {
+	public static function logData( $data ) {
 		if ( is_array( $data ) || is_object( $data ) ) {
 			fwrite( STDOUT, json_encode( $data, JSON_PRETTY_PRINT ) );
 			return;

--- a/tests/codeception/wpunit/WPGraphQLTestCaseTest.php
+++ b/tests/codeception/wpunit/WPGraphQLTestCaseTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\Constraint\IsTrue;
 class WPGraphQLTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 {
 	/**
@@ -138,5 +139,89 @@ class WPGraphQLTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 
 		// Assert response has error.
 		$this->assertQueryError( $response, $expected );
+	}
+
+	public function testComplexExpectedNodes() {
+		$post_id = $this->factory()->post->create();
+		$term_id = $this->factory()->term->create( array( 'taxonomy' => 'category' ) );
+		wp_set_object_terms( $post_id, array( $term_id ), 'category' );
+
+		$query = '
+			query {
+				posts {
+					nodes {
+						databaseId
+						categories {
+							nodes {
+								databaseId 
+							}
+						}
+					}
+				}
+			}
+		';
+
+		$response = $this->graphql( compact( 'query' ) );
+		$expected = array(
+			$this->expectedNode(
+				'posts.nodes',
+				array(
+					$this->expectedObject( 'databaseId', $post_id ),
+					$this->expectedNode(
+						'categories.nodes',
+						array(
+							$this->expectedObject( 'databaseId', $term_id )
+						),
+						0
+					)
+				)
+			)
+		);
+
+		$this->assertQuerySuccessful( $response, $expected );
+	}
+
+	public function testComplexExpectedEdges() {
+		$post_id = $this->factory()->post->create();
+		$term_id = $this->factory()->term->create( array( 'taxonomy' => 'category' ) );
+		wp_set_object_terms( $post_id, array( $term_id ), 'category' );
+
+		$query = '
+			query {
+				posts {
+					edges {
+						node {
+							databaseId
+							categories {
+								edges {
+									node {
+										databaseId 
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		';
+
+		$response = $this->graphql( compact( 'query' ) );
+		$expected = array(
+			$this->expectedEdge(
+				'posts.edges',
+				array(
+					$this->expectedObject( 'databaseId', $post_id ),
+					$this->expectedEdge(
+						'categories.edges',
+						array(
+							$this->expectedObject( 'databaseId', $term_id )
+						)
+					),
+				),
+				0
+			)
+		);
+
+		$this->assertQuerySuccessful( $response, $expected );
 	}
 }

--- a/tests/codeception/wpunit/WPGraphQLTestCaseTest.php
+++ b/tests/codeception/wpunit/WPGraphQLTestCaseTest.php
@@ -41,6 +41,8 @@ class WPGraphQLTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 
 		// Expected data.
 		$expected = array(
+			$this->expectedObject( 'post.id', null ), // If null provided, field existence is asserted.
+			$this->not()->expectedObject( 'post.id', 'null' ), // If "null" provided, asserts if field value is NULL.
 			$this->expectedObject( 'post.id', $this->toRelayId( 'post', $post_id ) ),
 			$this->expectedObject( 'post.databaseId', $post_id ),
 			$this->not()->expectedObject( 'post.databaseId', 10001 ),

--- a/tests/phpunit/unit/test-wpgraphqlunittestcase.php
+++ b/tests/phpunit/unit/test-wpgraphqlunittestcase.php
@@ -36,6 +36,8 @@ class WPGraphQLUnitTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLUnitT
 
 		// Expected data.
 		$expected = array(
+			$this->expectedObject( 'post.id', null ), // If null provided, field existence is asserted.
+			$this->not()->expectedObject( 'post.id', 'null' ), // If "null" provided, asserts if field value is NULL.
 			$this->expectedObject( 'post.id', $this->toRelayId( 'post', $post_id ) ),
 			$this->expectedObject( 'post.databaseId', $post_id ),
 			$this->not()->expectedObject( 'post.databaseId', 10001 ),


### PR DESCRIPTION
### Checklist
- Assertion refactor to be closer to what PHPUnit Docs recommend.
- Support added for nested rules. See example below
```php
$post_id = $this->factory()->post->create();
$term_id = $this->factory()->term->create( array( 'taxonomy' => 'category' ) );
wp_set_object_terms( $post_id, array( $term_id ), 'category' );

$query = '
	query {
		posts {
			nodes {
				databaseId
				categories {
					nodes {
						databaseId 
					}
				}
			}
		}
	}
';

$response = $this->graphql( compact( 'query' ) );
$expected = array(
	$this->expectedNode(
		'posts.nodes',
		array(
			$this->expectedObject( 'databaseId', $post_id ),
			$this->expectedNode(
				'categories.nodes',
				array(
					$this->expectedObject( 'databaseId', $term_id )
				),
				0
			)
		)
	)
);

$this->assertQuerySuccessful( $response, $expected );
```