### PR TITLE
"WPGraphQLTestCommon::expectedField()" added.

### DIFF
--- a/src/TestCase/WPGraphQLTestCase.php
+++ b/src/TestCase/WPGraphQLTestCase.php
@@ -16,6 +16,10 @@ class WPGraphQLTestCase extends \Codeception\TestCase\WPTestCase {
 
 	use WPGraphQLTestCommon;
 
+	// For capturing the resulting constraint of the assertion.
+	protected static $actual          = null;
+	protected static $last_constraint = null;
+
 	// Possible field anonymous values.
 	const NOT_NULL  = 'codecept_field_value_not_null';
 	const IS_NULL   = 'codecept_field_value_is_null';

--- a/src/TestCase/WPGraphQLTestCase.php
+++ b/src/TestCase/WPGraphQLTestCase.php
@@ -16,6 +16,12 @@ class WPGraphQLTestCase extends \Codeception\TestCase\WPTestCase {
 
 	use WPGraphQLTestCommon;
 
+	// Possible field anonymous values.
+	const NOT_NULL  = 'codecept_field_value_not_null';
+	const IS_NULL   = 'codecept_field_value_is_null';
+	const NOT_FALSY = 'codecept_field_value_is_falsy';
+	const IS_FALSY  = 'codecept_field_value_is_falsy';
+
 	// Search operation enumerations.
 	const MESSAGE_EQUALS      = 100;
 	const MESSAGE_CONTAINS    = 200;

--- a/src/TestCase/WPGraphQLUnitTestCase.php
+++ b/src/TestCase/WPGraphQLUnitTestCase.php
@@ -12,6 +12,10 @@ abstract class WPGraphQLUnitTestCase extends \WP_UnitTestCase {
 
 	use WPGraphQLTestCommon;
 
+	// For capturing the resulting constraint of the assertion.
+	protected static $actual          = null;
+	protected static $last_constraint = null;
+
 	// Possible field anonymous values.
 	const NOT_NULL  = 'phpunit_field_value_not_null';
 	const IS_NULL   = 'phpunit_field_value_is_null';

--- a/src/TestCase/WPGraphQLUnitTestCase.php
+++ b/src/TestCase/WPGraphQLUnitTestCase.php
@@ -12,6 +12,12 @@ abstract class WPGraphQLUnitTestCase extends \WP_UnitTestCase {
 
 	use WPGraphQLTestCommon;
 
+	// Possible field anonymous values.
+	const NOT_NULL  = 'phpunit_field_value_not_null';
+	const IS_NULL   = 'phpunit_field_value_is_null';
+	const NOT_FALSY = 'phpunit_field_value_is_falsy';
+	const IS_FALSY  = 'phpunit_field_value_is_falsy';
+
 	// Search operation enumerations.
 	const MESSAGE_EQUALS      = 500;
 	const MESSAGE_CONTAINS    = 600;

--- a/tests/codeception/wpunit/WPGraphQLTestCaseTest.php
+++ b/tests/codeception/wpunit/WPGraphQLTestCaseTest.php
@@ -41,11 +41,11 @@ class WPGraphQLTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 
 		// Expected data.
 		$expected = array(
-			$this->expectedObject( 'post.id', null ), // If null provided, field existence is asserted.
-			$this->not()->expectedObject( 'post.id', 'null' ), // If "null" provided, asserts if field value is NULL.
-			$this->expectedObject( 'post.id', $this->toRelayId( 'post', $post_id ) ),
-			$this->expectedObject( 'post.databaseId', $post_id ),
-			$this->not()->expectedObject( 'post.databaseId', 10001 ),
+			$this->expectedField( 'post.id', self::NOT_NULL ), // If null provided, field existence is asserted.
+			$this->not()->expectedField( 'post.id', self::IS_NULL ), // If "null" provided, asserts if field value is NULL.
+			$this->expectedField( 'post.id', $this->toRelayId( 'post', $post_id ) ),
+			$this->expectedField( 'post.databaseId', $post_id ),
+			$this->not()->expectedField( 'post.databaseId', 10001 ),
 			$this->expectedNode(
 				'posts.nodes',
 				array( 'id' => $this->toRelayId( 'post', $post_id ) )
@@ -53,7 +53,36 @@ class WPGraphQLTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 			$this->not()->expectedNode(
 				'posts.nodes',
 				array( 'id' => $this->toRelayId( 'post', 10001 ) )
-			)
+			),
+
+			$this->expectedObject(
+				'post',
+				array(
+					$this->expectedField( 'id', self::NOT_FALSY ),
+					$this->not()->expectedField( 'id', self::IS_FALSY ),
+					$this->expectedField( 'id', $this->toRelayId( 'post', $post_id ) ),
+					$this->expectedField( 'databaseId', $post_id ),
+					$this->not()->expectedField( 'databaseId', 10001 ),
+				)
+			),
+			$this->expectedObject(
+				'posts',
+				array(
+					$this->expectedNode(
+						'nodes',
+						array(
+							$this->expectedField( 'id', $this->toRelayId( 'post', $post_id ) )
+						)
+					),
+					$this->not()->expectedNode(
+						'nodes',
+						array(
+							$this->expectedField( 'id', $this->toRelayId( 'post', 10001 ) )
+						)
+					),
+				)
+			),
+
 		);
 
 		// Assert query successful.
@@ -123,8 +152,8 @@ class WPGraphQLTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 			$this->expectedErrorMessage( 'worked as', self::MESSAGE_CONTAINS ),
 			$this->expectedErrorMessage( 'as expected', self::MESSAGE_ENDS_WITH ),
 			$this->expectedErrorMessage( 'testErrorQuery worked', self::MESSAGE_STARTS_WITH ),
-			$this->expectedObject( 'testFailingType.try', 'NULL' ),
-			$this->expectedObject( 'testFailingType.trying', [ 'No', 'fails', 'here', 'either' ] ),
+			$this->expectedField( 'testFailingType.try', self::IS_NULL ),
+			$this->expectedField( 'testFailingType.trying', [ 'No', 'fails', 'here', 'either' ] ),
 		);
 
 		// Assert response has error.
@@ -135,8 +164,8 @@ class WPGraphQLTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 
 		$expected = array(
 			$this->expectedErrorPath( 'testFailingType.trying' ),
-			$this->expectedObject( 'testFailingType.try', 'No fails here' ),
-			$this->expectedObject( 'testFailingType.trying', 'NULL' ),
+			$this->expectedField( 'testFailingType.try', 'No fails here' ),
+			$this->expectedField( 'testFailingType.trying', self::IS_NULL ),
 		);
 
 		// Assert response has error.
@@ -168,11 +197,11 @@ class WPGraphQLTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 			$this->expectedNode(
 				'posts.nodes',
 				array(
-					$this->expectedObject( 'databaseId', $post_id ),
+					$this->expectedField( 'databaseId', $post_id ),
 					$this->expectedNode(
 						'categories.nodes',
 						array(
-							$this->expectedObject( 'databaseId', $term_id )
+							$this->expectedField( 'databaseId', $term_id )
 						),
 						0
 					)
@@ -191,6 +220,9 @@ class WPGraphQLTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$query = '
 			query {
 				posts {
+					pageInfo {
+						hasPreviousPage
+					}
 					edges {
 						node {
 							databaseId
@@ -209,14 +241,20 @@ class WPGraphQLTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 
 		$response = $this->graphql( compact( 'query' ) );
 		$expected = array(
+			$this->expectedObject(
+				'posts.pageInfo',
+				array(
+					$this->expectedField( 'hasPreviousPage', false )
+				),
+			),
 			$this->expectedEdge(
 				'posts.edges',
 				array(
-					$this->expectedObject( 'databaseId', $post_id ),
+					$this->expectedField( 'databaseId', $post_id ),
 					$this->expectedEdge(
 						'categories.edges',
 						array(
-							$this->expectedObject( 'databaseId', $term_id )
+							$this->expectedField( 'databaseId', $term_id )
 						)
 					),
 				),

--- a/tests/phpunit/unit/test-wpgraphqlunittestcase.php
+++ b/tests/phpunit/unit/test-wpgraphqlunittestcase.php
@@ -36,11 +36,11 @@ class WPGraphQLUnitTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLUnitT
 
 		// Expected data.
 		$expected = array(
-			$this->expectedObject( 'post.id', null ), // If null provided, field existence is asserted.
-			$this->not()->expectedObject( 'post.id', 'null' ), // If "null" provided, asserts if field value is NULL.
-			$this->expectedObject( 'post.id', $this->toRelayId( 'post', $post_id ) ),
-			$this->expectedObject( 'post.databaseId', $post_id ),
-			$this->not()->expectedObject( 'post.databaseId', 10001 ),
+			$this->expectedField( 'post.id', self::NOT_NULL ), // If null provided, field existence is asserted.
+			$this->not()->expectedField( 'post.id', self::IS_NULL ), // If "null" provided, asserts if field value is NULL.
+			$this->expectedField( 'post.id', $this->toRelayId( 'post', $post_id ) ),
+			$this->expectedField( 'post.databaseId', $post_id ),
+			$this->not()->expectedField( 'post.databaseId', 10001 ),
 			$this->expectedNode(
 				'posts.nodes',
 				array( 'id' => $this->toRelayId( 'post', $post_id ) )
@@ -48,7 +48,36 @@ class WPGraphQLUnitTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLUnitT
 			$this->not()->expectedNode(
 				'posts.nodes',
 				array( 'id' => $this->toRelayId( 'post', 10001 ) )
-			)
+			),
+
+			$this->expectedObject(
+				'post',
+				array(
+					$this->expectedField( 'id', self::NOT_FALSY ),
+					$this->not()->expectedField( 'id', self::IS_FALSY ),
+					$this->expectedField( 'id', $this->toRelayId( 'post', $post_id ) ),
+					$this->expectedField( 'databaseId', $post_id ),
+					$this->not()->expectedField( 'databaseId', 10001 ),
+				)
+			),
+			$this->expectedObject(
+				'posts',
+				array(
+					$this->expectedNode(
+						'nodes',
+						array(
+							$this->expectedField( 'id', $this->toRelayId( 'post', $post_id ) )
+						)
+					),
+					$this->not()->expectedNode(
+						'nodes',
+						array(
+							$this->expectedField( 'id', $this->toRelayId( 'post', 10001 ) )
+						)
+					),
+				)
+			),
+
 		);
 
 		// Assert query successful.
@@ -118,8 +147,8 @@ class WPGraphQLUnitTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLUnitT
 			$this->expectedErrorMessage( 'worked as', self::MESSAGE_CONTAINS ),
 			$this->expectedErrorMessage( 'as expected', self::MESSAGE_ENDS_WITH ),
 			$this->expectedErrorMessage( 'testErrorQuery worked', self::MESSAGE_STARTS_WITH ),
-			$this->expectedObject( 'testFailingType.try', 'NULL' ),
-			$this->expectedObject( 'testFailingType.trying', [ 'No', 'fails', 'here', 'either' ] ),
+			$this->expectedField( 'testFailingType.try', self::IS_NULL ),
+			$this->expectedField( 'testFailingType.trying', [ 'No', 'fails', 'here', 'either' ] ),
 		);
 
 		// Assert response has error.
@@ -130,8 +159,8 @@ class WPGraphQLUnitTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLUnitT
 
 		$expected = array(
 			$this->expectedErrorPath( 'testFailingType.trying' ),
-			$this->expectedObject( 'testFailingType.try', 'No fails here' ),
-			$this->expectedObject( 'testFailingType.trying', 'NULL' ),
+			$this->expectedField( 'testFailingType.try', 'No fails here' ),
+			$this->expectedField( 'testFailingType.trying', self::IS_NULL ),
 		);
 
 		// Assert response has error.
@@ -163,11 +192,11 @@ class WPGraphQLUnitTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLUnitT
 			$this->expectedNode(
 				'posts.nodes',
 				array(
-					$this->expectedObject( 'databaseId', $post_id ),
+					$this->expectedField( 'databaseId', $post_id ),
 					$this->expectedNode(
 						'categories.nodes',
 						array(
-							$this->expectedObject( 'databaseId', $term_id )
+							$this->expectedField( 'databaseId', $term_id )
 						),
 						0
 					)
@@ -186,6 +215,9 @@ class WPGraphQLUnitTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLUnitT
 		$query = '
 			query {
 				posts {
+					pageInfo {
+						hasPreviousPage
+					}
 					edges {
 						node {
 							databaseId
@@ -204,14 +236,20 @@ class WPGraphQLUnitTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLUnitT
 
 		$response = $this->graphql( compact( 'query' ) );
 		$expected = array(
+			$this->expectedObject(
+				'posts.pageInfo',
+				array(
+					$this->expectedField( 'hasPreviousPage', false )
+				),
+			),
 			$this->expectedEdge(
 				'posts.edges',
 				array(
-					$this->expectedObject( 'databaseId', $post_id ),
+					$this->expectedField( 'databaseId', $post_id ),
 					$this->expectedEdge(
 						'categories.edges',
 						array(
-							$this->expectedObject( 'databaseId', $term_id )
+							$this->expectedField( 'databaseId', $term_id )
 						)
 					),
 				),


### PR DESCRIPTION
This update introduces some much need features and fixes some design flaws. 

- Anonymous field value constants introduced `$this->expectedField( 'some.field', self::IS_NULL )`. They should be used with the following values match the expected value desired.
  - `IS_NULL`
  - `NOT_NULL`
  - `IS_FALSY`
  - `NOT_FALSY`
- `WPGraphQLTestCommon::expectedField()` added. This should be use when specific the value of a field.
- `WPGraphQLTestCommon::expectedObject() refactored. This should now be use when specific a group of sub rules on one path. See the example below for better understanding.
```
$this->expectedObject(
  'post',
  array(
    $this->expectedField( 'id', $this->toRelayId( 'post', 100 ) ),
    $this->expectedField( 'databaseId', 100 ),
    $this->not()->expectedField( 'databaseId', 101 ),
)
```

- Better assertion usage and console error reporting in non-verbose modes.