### PR TITLE
fix: correctly fail when data doesnt match

### DIFF
--- a/src/TestCase/WPGraphQLTestCommon.php
+++ b/src/TestCase/WPGraphQLTestCommon.php
@@ -601,7 +601,7 @@ trait WPGraphQLTestCommon {
 			foreach( $expected as $expected_data ) {
 				$data_passing = static::_assertExpectedDataFound( $response, $expected_data, '', $message );
 				if ( ! $data_passing ) {
-					break;
+					static::fail( $message );
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #14 and #15 by `fail()`ing immediately when `$data_passing` comes back false.

## To test: 
Run the reproduction cases in the mentioned issues.
