### PR TITLE
fix: check if `$this->not` property is set before attempting to access.

### DIFF
--- a/src/TestCase/WPGraphQLTestCommon.php
+++ b/src/TestCase/WPGraphQLTestCommon.php
@@ -141,7 +141,11 @@ trait WPGraphQLTestCommon {
 	 * @return string
 	 */
 	private function get_not() {
-		$prefix = $this->not ? '!' : '';
+		if ( ! isset( $this->not ) ) {
+			return '';
+		}
+
+		$prefix = $this->not;
 		unset( $this->not );
 		return $prefix;
 	}


### PR DESCRIPTION
## Description

This PR is related to the issue #23 -- details are outlined there, but I can also copy those here if you'd like.

Due to issues encountered setting up my local environment to run the local test suite, I'm unable to provide test results or steps to test locally using PHPUnit (see issue #22).

However, I can confirm that this code fixes the issue I encountered when running PHPUnit in the project I'm working on. Successful test output below.

<details>
<summary>Successful Test Output</summary>

```
composer test -- tests/themes/trd-news/theme-setup/wpgraphql/queries/RedirectTest.php 
> php8.1 ./vendor/bin/phpunit --configuration phpunit.xml 'tests/themes/trd-news/theme-setup/wpgraphql/queries/RedirectTest.php'
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 9.6.6 by Sebastian Bergmann and contributors.

PHP Deprecated:  Return type of GraphQL\Type\Definition\Type::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /workspaces/trd-news-back-end/wordpress/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Type/Definition/Type.php on line 311
PHP Deprecated:  Return type of GraphQL\Language\SourceLocation::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /workspaces/trd-news-back-end/wordpress/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Language/SourceLocation.php on line 49
PHP Deprecated:  Return type of GraphQL\Language\AST\NodeList::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /workspaces/trd-news-back-end/wordpress/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Language/AST/NodeList.php on line 72
PHP Deprecated:  Return type of GraphQL\Executor\ExecutionResult::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /workspaces/trd-news-back-end/wordpress/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Executor/ExecutionResult.php on line 118
{
    "data": {
        "post": {
            "id": "cG9zdDo0",
            "databaseId": 4
        },
        "posts": {
            "nodes": [
                {
                    "id": "cG9zdDo1"
                },
                {
                    "id": "cG9zdDo0"
                }
            ]
        }
    },
    "extensions": {
        "debug": [
            {
                "type": "DEBUG_LOGS_INACTIVE",
                "message": "GraphQL Debug logging is not active. To see debug logs, GRAPHQL_DEBUG must be enabled."
            }
        ]
    }
}{
    "PATH": "data.post.id",
    "UNWANTED_VALUE": null,
    "ACTUAL_DATA": "cG9zdDo0"
}{
    "PATH": "data.post.id",
    "WANTED_VALUE": "cG9zdDo0",
    "ACTUAL_DATA": "cG9zdDo0"
}{
    "PATH": "data.post.databaseId",
    "WANTED_VALUE": 4,
    "ACTUAL_DATA": 4
}{
    "PATH": "data.post.databaseId",
    "UNWANTED_VALUE": 10001,
    "ACTUAL_DATA": 4
}{
    "PATH": "data.posts.nodes",
    "WANTED VALUE": {
        "id": "cG9zdDo0"
    },
    "VALUES_AT_LOCATION": [
        {
            "id": "cG9zdDo1"
        },
        {
            "id": "cG9zdDo0"
        }
    ]
}{
    "PATH": "data.posts.nodes",
    "WANTED_VALUE": {
        "id": "cG9zdDo0"
    },
    "ACTUAL_DATA_OBJECT": {
        "id": "cG9zdDo1"
    }
}{
    "PATH": "data.posts.nodes",
    "WANTED_VALUE": {
        "id": "cG9zdDo0"
    },
    "ACTUAL_DATA_OBJECT": {
        "id": "cG9zdDo0"
    }
}{
    "PATH": "data.posts.nodes",
    "UNWANTED VALUE": {
        "id": "cG9zdDoxMDAwMQ=="
    },
    "VALUES_AT_LOCATION": [
        {
            "id": "cG9zdDo1"
        },
        {
            "id": "cG9zdDo0"
        }
    ]
}{
    "PATH": "data.posts.nodes",
    "UNWANTED_VALUE": {
        "id": "cG9zdDoxMDAwMQ=="
    },
    "ACTUAL_DATA_OBJECT": {
        "id": "cG9zdDo1"
    }
}{
    "PATH": "data.posts.nodes",
    "UNWANTED_VALUE": {
        "id": "cG9zdDoxMDAwMQ=="
    },
    "ACTUAL_DATA_OBJECT": {
        "id": "cG9zdDo0"
    }
}{
    "PATH": "data.post.id",
    "WANTED_VALUE": "cG9zdDo0",
    "ACTUAL_DATA": "cG9zdDo0"
}{
    "PATH": "data.post.databaseId",
    "WANTED_VALUE": 4,
    "ACTUAL_DATA": 4
}{
    "PATH": "data.post.databaseId",
    "UNWANTED_VALUE": 10001,
    "ACTUAL_DATA": 4
}{
    "PATH": "data.posts.nodes.#.id",
    "WANTED VALUE": "cG9zdDo0",
    "VALUES_AT_LOCATION": [
        "cG9zdDo1",
        "cG9zdDo0"
    ]
}{
    "PATH": "data.posts.nodes.#.id",
    "WANTED_VALUE": "cG9zdDo0",
    "ACTUAL_DATA": "cG9zdDo1"
}{
    "PATH": "data.posts.nodes.#.id",
    "WANTED_VALUE": "cG9zdDo0",
    "ACTUAL_DATA": "cG9zdDo0"
}{
    "PATH": "data.posts.nodes.#.id",
    "UNWANTED VALUE": "cG9zdDoxMDAwMQ==",
    "VALUES_AT_LOCATION": [
        "cG9zdDo1",
        "cG9zdDo0"
    ]
}{
    "PATH": "data.posts.nodes.#.id",
    "UNWANTED_VALUE": "cG9zdDoxMDAwMQ==",
    "ACTUAL_DATA": "cG9zdDo1"
}{
    "PATH": "data.posts.nodes.#.id",
    "UNWANTED_VALUE": "cG9zdDoxMDAwMQ==",
    "ACTUAL_DATA": "cG9zdDo0"
}.
Deprecated: Return type of GraphQL\Type\Definition\Type::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /workspaces/trd-news-back-end/wordpress/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Type/Definition/Type.php on line 311

Deprecated: Return type of GraphQL\Language\SourceLocation::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /workspaces/trd-news-back-end/wordpress/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Language/SourceLocation.php on line 49

Deprecated: Return type of GraphQL\Language\AST\NodeList::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /workspaces/trd-news-back-end/wordpress/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Language/AST/NodeList.php on line 72

Deprecated: Return type of GraphQL\Executor\ExecutionResult::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /workspaces/trd-news-back-end/wordpress/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Executor/ExecutionResult.php on line 118
PHP Deprecated:  Return type of GraphQL\Error\Error::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /workspaces/trd-news-back-end/wordpress/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Error/Error.php on line 370
{
    "errors": [
        {
            "message": "testErrorQuery worked as expected",
            "extensions": {
                "category": "user"
            },
            "locations": [
                {
                    "line": 3,
                    "column": 5
                }
            ],
            "path": [
                "testFailingType",
                "try"
            ]
        }
    ],
    "data": {
        "testFailingType": {
            "try": null,
            "trying": [
                "No",
                "fails",
                "here",
                "either"
            ]
        }
    },
    "extensions": {
        "debug": [
            {
                "type": "DEBUG_LOGS_INACTIVE",
                "message": "GraphQL Debug logging is not active. To see debug logs, GRAPHQL_DEBUG must be enabled."
            }
        ]
    }
}{
    "PATH": "data.testFailingType.try",
    "WANTED_VALUE": null,
    "ACTUAL_DATA": null
}{
    "PATH": "data.testFailingType.trying",
    "WANTED_VALUE": [
        "No",
        "fails",
        "here",
        "either"
    ],
    "ACTUAL_DATA_OBJECT": [
        "No",
        "fails",
        "here",
        "either"
    ]
}{
    "errors": [
        {
            "message": "Internal server error",
            "extensions": {
                "category": "internal"
            },
            "locations": [
                {
                    "line": 4,
                    "column": 5
                }
            ],
            "path": [
                "testFailingType",
                "trying"
            ]
        }
    ],
    "data": {
        "testFailingType": {
            "try": "No fails here",
            "trying": null
        }
    },
    "extensions": {
        "debug": [
            {
                "type": "DEBUG_LOGS_INACTIVE",
                "message": "GraphQL Debug logging is not active. To see debug logs, GRAPHQL_DEBUG must be enabled."
            }
        ]
    }
}{
    "PATH": "data.testFailingType.try",
    "WANTED_VALUE": "No fails here",
    "ACTUAL_DATA": "No fails here"
}{
    "PATH": "data.testFailingType.trying",
    "WANTED_VALUE": null,
    "ACTUAL_DATA": null
}.
Deprecated: Return type of GraphQL\Error\Error::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /workspaces/trd-news-back-end/wordpress/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Error/Error.php on line 370
{
    "data": {
        "posts": {
            "nodes": [
                {
                    "databaseId": 6,
                    "categories": {
                        "nodes": [
                            {
                                "databaseId": 9
                            }
                        ]
                    }
                }
            ]
        }
    },
    "extensions": {
        "debug": [
            {
                "type": "DEBUG_LOGS_INACTIVE",
                "message": "GraphQL Debug logging is not active. To see debug logs, GRAPHQL_DEBUG must be enabled."
            }
        ]
    }
}{
    "PATH": "data.posts.nodes.#.databaseId",
    "WANTED VALUE": 6,
    "VALUES_AT_LOCATION": [
        6
    ]
}{
    "PATH": "data.posts.nodes.#.databaseId",
    "WANTED_VALUE": 6,
    "ACTUAL_DATA": 6
}{
    "PATH": "data.posts.nodes.#.categories.nodes.0.databaseId",
    "WANTED VALUE": 9,
    "VALUES_AT_LOCATION": [
        9
    ]
}{
    "PATH": "data.posts.nodes.#.categories.nodes.0.databaseId",
    "WANTED_VALUE": 9,
    "ACTUAL_DATA": 9
}.{
    "data": {
        "posts": {
            "pageInfo": {
                "hasPreviousPage": false
            },
            "edges": [
                {
                    "node": {
                        "databaseId": 7,
                        "categories": {
                            "edges": [
                                {
                                    "node": {
                                        "databaseId": 10
                                    }
                                }
                            ]
                        }
                    }
                }
            ]
        }
    },
    "extensions": {
        "debug": [
            {
                "type": "DEBUG_LOGS_INACTIVE",
                "message": "GraphQL Debug logging is not active. To see debug logs, GRAPHQL_DEBUG must be enabled."
            }
        ]
    }
}{
    "PATH": "data.posts.pageInfo.hasPreviousPage",
    "WANTED_VALUE": false,
    "ACTUAL_DATA": false
}{
    "PATH": "data.posts.edges.0.node.databaseId",
    "WANTED_VALUE": 7,
    "ACTUAL_DATA": 7
}{
    "PATH": "data.posts.edges.0.node.categories.edges.#.node.databaseId",
    "WANTED VALUE": 10,
    "VALUES_AT_LOCATION": [
        10
    ]
}{
    "PATH": "data.posts.edges.0.node.categories.edges.#.node.databaseId",
    "WANTED_VALUE": 10,
    "ACTUAL_DATA": 10
}.                                                                4 / 4 (100%)

Time: 00:01.413, Memory: 98.50 MB

OK (4 tests, 5 assertions)
```

</details>

## Screenshots

### Before Fix:

![image](https://github.com/wp-graphql/wp-graphql-testcase/assets/4269287/edd08733-3d37-448b-bd55-0fb0b053572b)

### After Fix:

![image](https://github.com/wp-graphql/wp-graphql-testcase/assets/4269287/e78d80ec-3101-4619-9d61-4b1cacf17140)


