### PR TITLE
Update dependencies and Dockerfile versions for CI

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -58,12 +58,10 @@ jobs:
 
       - name: Push Codecoverage to Coveralls.io
         env:
-          COVERALLS_RUN_LOCALLY: 1
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           docker-compose run --rm \
           --workdir=/var/www/html/wp-content/plugins/wp-graphql-testcase \
           --user $(id -u) \
-          -e COVERALLS_RUN_LOCALLY=1 -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN \
           wordpress \
           vendor/bin/php-coveralls -v

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -32,14 +32,29 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: json, mbstring
 
-      - name: Install Dependencies
-        run: composer install
+      - name: Install WP PHPUnit Dependencies
+        run:  |
+          composer install --ignore-platform-reqs
+          composer require wp-phpunit/wp-phpunit \
+          yoast/phpunit-polyfills \
+          phpunit/phpunit:^9.6 \
+          wp-phpunit/wp-phpunit \
+
+      - name: Run PHPUnit Tests w/ Docker.
+        run: composer run-phpunit -- -- --coverage-text
+
+      - name: Install WPBrowser Dependencies
+        run: |
+          composer install --ignore-platform-reqs
+          composer require codeception/module-asserts:* \
+          codeception/util-universalframework:* \
+          codeception/module-rest:* \
+          lucatume/wp-browser:^3.1 --ignore-platform-reqs
 
       - name: Run Codeception Tests w/ Docker.
         run: composer run-codeception -- -- --coverage --coverage-xml
 
-      - name: Run PHPUnit Tests w/ Docker.
-        run: composer run-phpunit -- -- --coverage-text
+
 
       - name: Push Codecoverage to Coveralls.io
         env:

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -63,5 +63,6 @@ jobs:
           docker-compose run --rm \
           --workdir=/var/www/html/wp-content/plugins/wp-graphql-testcase \
           --user $(id -u) \
+          -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN \
           wordpress \
           vendor/bin/php-coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,6 @@
         "squizlabs/php_codesniffer": "^3.5",
         "automattic/vipwpcs": "^2.3",
         "wp-coding-standards/wpcs": "^2.3",
-        "wp-phpunit/wp-phpunit": "^6.3",
-        "yoast/phpunit-polyfills": "^2.0",
-        "phpunit/phpunit": "^9.6",
-        "codeception/module-asserts": "*",
-        "codeception/util-universalframework": "*",
-        "codeception/module-rest": "*",
-        "lucatume/wp-browser": "^4.1",
         "php-coveralls/php-coveralls": "2.4.3"
     },
     "scripts": {
@@ -54,7 +47,9 @@
         "codeception/util-universalframework": "Needed for \\Tests\\WPGraphQL\\TestCase\\WPGraphQLTestcase to work.",
         "codeception/module-rest": "Needed for \\Tests\\WPGraphQL\\TestCase\\WPGraphQLTestcase to work.",
         "lucatume/wp-browser": "Needed for \\Tests\\WPGraphQL\\TestCase\\WPGraphQLTestcase to work.",
-        "wp-phpunit/wp-phpunit": "Needed for \\Tests\\WPGraphQL\\TestCase\\WPGraphQLUnitTestcase to work."
+        "phpunit/phpunit": "Needed for \\Tests\\WPGraphQL\\TestCase\\WPGraphQLUnitTestcase to work.",
+        "wp-phpunit/wp-phpunit": "Needed for \\Tests\\WPGraphQL\\TestCase\\WPGraphQLUnitTestcase to work.",
+        "yoast/phpunit-polyfills": "Needed for \\Tests\\WPGraphQL\\TestCase\\WPGraphQLUnitTestcase to work."
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "wp-phpunit/wp-phpunit": "^6.3",
         "yoast/phpunit-polyfills": "^2.0",
         "phpunit/phpunit": "^9.6",
-        "codeception/codeception": "^5.1",
         "codeception/module-asserts": "*",
         "codeception/util-universalframework": "*",
         "codeception/module-rest": "*",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         ]
     },
     "require": {
-        "php": "^7.1 || ^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
         "composer/installers": "^1.9",
@@ -30,10 +30,11 @@
         "wp-phpunit/wp-phpunit": "^6.3",
         "yoast/phpunit-polyfills": "^2.0",
         "phpunit/phpunit": "^9.6",
+        "codeception/codeception": "^5.1",
         "codeception/module-asserts": "*",
         "codeception/util-universalframework": "*",
         "codeception/module-rest": "*",
-        "lucatume/wp-browser": "^3.1",
+        "lucatume/wp-browser": "^4.1",
         "php-coveralls/php-coveralls": "2.4.3"
     },
     "scripts": {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,9 @@
-ARG PHP_VERSION=7.4
+ARG PHP_VERSION=8.1
 
 FROM wordpress:php${PHP_VERSION}-apache
 
-ARG XDEBUG_VERSION=2.9.6
+# See: https://xdebug.org/docs/compat to match the Xdebug version with the PHP version.
+ARG XDEBUG_VERSION=3.3.1
 
 RUN apt-get update; \
 	apt-get install -y --no-install-recommends \
@@ -13,7 +14,6 @@ RUN apt-get update; \
 
 COPY php.ini /usr/local/etc/php/php.ini
 
-# Setup xdebug. The latest version supported by PHP 5.6 is 2.5.5.
 RUN	pecl install "xdebug-${XDEBUG_VERSION}"; \
 	docker-php-ext-enable xdebug
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,8 @@ COPY php.ini /usr/local/etc/php/php.ini
 RUN	pecl install "xdebug-${XDEBUG_VERSION}"; \
 	docker-php-ext-enable xdebug
 
+ENV XDEBUG_MODE=coverage
+
 # Install PDO MySQL driver.
 RUN docker-php-ext-install \
 	pdo_mysql

--- a/local/config/wp-config.php
+++ b/local/config/wp-config.php
@@ -12,6 +12,17 @@ define( 'DB_HOST', 'mysql' );
 define( 'DB_CHARSET', 'utf8' );
 define( 'DB_COLLATE', '' );
 
+$table_prefix = 'wptests_';
+
+define( 'AUTH_KEY',         'value' );
+define( 'SECURE_AUTH_KEY',  'value' );
+define( 'LOGGED_IN_KEY',    'value' );
+define( 'NONCE_KEY',        'value' );
+define( 'AUTH_SALT',        'value' );
+define( 'SECURE_AUTH_SALT', 'value' );
+define( 'LOGGED_IN_SALT',   'value' );
+define( 'NONCE_SALT',       'value' );
+
 define( 'ABSPATH', __DIR__ . '/' );
 
 require_once ABSPATH . 'wp-settings.php';

--- a/src/TestCase/WPGraphQLTestCommon.php
+++ b/src/TestCase/WPGraphQLTestCommon.php
@@ -837,24 +837,6 @@ trait WPGraphQLTestCommon {
 	}
 
 	/**
-	 * Wrapper for IsTrue constraint.
-	 *
-	 * @return IsTrue
-	 */
-	public static function isTrue(): IsTrue {
-        return new IsTrue;
-    }
-
-	/**
-	 * Wrapper for IsEmpty constraint.
-	 *
-	 * @return IsEmpty
-	 */
-	public static function isEmpty(): IsEmpty {
-        return new IsEmpty;
-    }
-
-	/**
 	 * Wrapper for IsEqual constraint.
 	 *
 	 * @param mixed $value  Desired contained value
@@ -874,23 +856,5 @@ trait WPGraphQLTestCommon {
 	 */
     public static function contains( $value ): TraversableContainsIdentical {
         return new TraversableContainsIdentical( $value );
-    }
-
-	/**
-	 * Wrapper for IsNull constraint.
-	 *
-	 * @return IsNull
-	 */
-	public static function isNull(): IsNull {
-        return new IsNull;
-    }
-
-	/**
-	 * Wrapper for LogicalNot constraint.
-	 *
-	 * @return LogicalNot
-	 */
-    public static function logicalNot( Constraint $last_constraint ): LogicalNot {
-        return new LogicalNot( $last_constraint );
     }
 }


### PR DESCRIPTION
## Description

This PR updates a few dependencies:

- PHP version in `composer.json`'s `require` to minimum `8.1` to match the workflow matrix minimum.
- `lucatime/wpbrowser` to latest.
- PHP version in Dockerfile to `8.1`
- XDebug version in Dockerfile to `3.3.1` to work with PHP `8.1` (see https://xdebug.org/docs/compat)

After updating the dependencies and Dockerfile, a few values needed to be set:

- `ENV` for XDebug coverage in Dockerfile
- WP values in `local/config/wp-config.php` file for Codeception. Without these values, there were errors and the `run-codeception` script would fail.

## Testing

To test locally, checkout this branch, then delete the following files/folders from local:

![image](https://github.com/wp-graphql/wp-graphql-testcase/assets/4269287/1a7961a8-cc8f-48bb-9339-6af58467943a)

Then, run:

- `composer install`
- `docker-compose up -d --build --force-recreate`
- `composer run-codeception -- -- --coverage --coverage-xml`
- `composer run-phpunit -- -- --coverage-text`

All should run successfully.

Example of passing CI: https://github.com/missionmike/wp-graphql-testcase/actions/runs/8649079504