### PR TITLE
fix: Assert query successful fix

### DIFF
--- a/src/TestCase/WPGraphQLTestCommon.php
+++ b/src/TestCase/WPGraphQLTestCommon.php
@@ -670,9 +670,9 @@ trait WPGraphQLTestCommon {
 	 * @param string $message   Error message.
 	 * @return void
 	 */
-	public function assertQueryError( array $response, array $expected, $message = null ) {
-		$error_passing  = null;  // Create individual error rule evaluation flag for later use.
-		$data_passing    = null;  // Create individual data rule evaluation flag for later use.
+	public function assertQueryError( array $response, array $expected = [], $message = null ) {
+		$error_passing   = null;  // Create individual error rule evaluation flag for later use.
+		$data_passing    = empty( $expected );  // Create individual data rule evaluation flag for later use.
 		$response_valid  = static::_assertIsValidQueryResponse( $response, $message ); // Validate response shape with sub assertion.
 		$response_failed = in_array( 'errors', array_keys( $response ) ); // Ensure no errors thrown.
 

--- a/src/TestCase/WPGraphQLTestCommon.php
+++ b/src/TestCase/WPGraphQLTestCommon.php
@@ -625,11 +625,11 @@ trait WPGraphQLTestCommon {
 	 * @param array  $expected  List of expected data objects.
 	 * @param string $message   Error message.
 	 */
-	public static function assertQuerySuccessful( array $response, array $expected, $message = null ) {
+	public static function assertQuerySuccessful( array $response, array $expected = [], $message = null ) {
 		static::$actual          = null;
 		static::$last_constraint = null;
 
-		$data_passing        = null;  // Create individual data rule evaluation flag for later use.
+		$data_passing        = empty( $expected );  // Create individual data rule evaluation flag for later use.
 		$response_valid      = static::_assertIsValidQueryResponse( $response, $message ); // Validate response shape with sub assertion.
 		$response_successful = ! in_array( 'errors', array_keys( $response ) ); // Ensure no errors thrown.
 

--- a/tests/codeception/wpunit/WPGraphQLTestCaseTest.php
+++ b/tests/codeception/wpunit/WPGraphQLTestCaseTest.php
@@ -87,6 +87,12 @@ class WPGraphQLTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 
 		// Assert query successful.
 		$this->assertQuerySuccessful( $response, $expected );
+
+		// Assert query successful with no expected rules.
+		$this->assertQuerySuccessful( $response );
+
+		// Assert query successful with no expected rules.
+		$this->assertQuerySuccessful( $response, [], 'Query returned errors' );
 	}
 
 	public function testAssertQueryError() {

--- a/tests/codeception/wpunit/WPGraphQLTestCaseTest.php
+++ b/tests/codeception/wpunit/WPGraphQLTestCaseTest.php
@@ -176,6 +176,12 @@ class WPGraphQLTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 
 		// Assert response has error.
 		$this->assertQueryError( $response, $expected );
+
+		// Assert response has error with no expected rules.
+		$this->assertQueryError( $response );
+
+		// Assert response has error with no expected rules and a message.
+		$this->assertQueryError( $response, [], 'Query return with no errors' );
 	}
 
 	public function testComplexExpectedNodes() {

--- a/tests/phpunit/unit/test-wpgraphqlunittestcase.php
+++ b/tests/phpunit/unit/test-wpgraphqlunittestcase.php
@@ -82,6 +82,12 @@ class WPGraphQLUnitTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLUnitT
 
 		// Assert query successful.
 		$this->assertQuerySuccessful( $response, $expected );
+
+		// Assert query successful with no expected rules.
+		$this->assertQuerySuccessful( $response );
+
+		// Assert query successful with no expected rules.
+		$this->assertQuerySuccessful( $response, [], 'Query returned errors' );
 	}
 
 	public function test_AssertQueryError() {

--- a/tests/phpunit/unit/test-wpgraphqlunittestcase.php
+++ b/tests/phpunit/unit/test-wpgraphqlunittestcase.php
@@ -171,6 +171,12 @@ class WPGraphQLUnitTestCaseTest extends \Tests\WPGraphQL\TestCase\WPGraphQLUnitT
 
 		// Assert response has error.
 		$this->assertQueryError( $response, $expected );
+
+		// Assert response has error with no expected rules.
+		$this->assertQueryError( $response );
+
+		// Assert response has error with no expected rules and a message.
+		$this->assertQueryError( $response, [], 'Query return with no errors' );
 	}
 
 	public function test_ComplexExpectedNodes() {


### PR DESCRIPTION
# Summary

Makes **$expected** optional in `assertQuerySuccessful` and `assertQueryError`